### PR TITLE
Nominating Intuit as the new member

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Core Member Organizations:
 - Autodesk
 - Salesforce
 - Twilio
+- Intuit
 
 ## Steering Committee
 


### PR DESCRIPTION
- Intuit is intersted in joining CNOE
- Henrik Blixt will represent Intuit in CNOE
- Legal approvals for their logo to be listed as a core member is in the works