### PR TITLE
adding Cisco as a new member

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Core Member Organizations:
 - Salesforce
 - Twilio
 - Intuit
+- Cisco
 
 ## Steering Committee
 


### PR DESCRIPTION
- Cisco is intersted in joining CNOE
- Hasith Kalpage  will represent Cisco in CNOE
- Legal approvals are done