### PR TITLE
Add initial SIG-Content

### DIFF
--- a/sigs/content/charter.md
+++ b/sigs/content/charter.md
@@ -16,3 +16,13 @@ Content within the code repositories of our tools, such as in-repository documen
 # Roles and Organization Management
 
 ## Leadership
+
+# Process
+
+## Meetings
+
+TBD
+
+## Communication
+
+Communication primarily occurs in the [#cnoe-initerest](https://cloud-native.slack.com/archives/C05TN9WFN5S) channel on CNCF slack.

--- a/sigs/content/charter.md
+++ b/sigs/content/charter.md
@@ -1,0 +1,18 @@
+# SIG Content
+
+This charter adheres to the conventions described in the [Kubernetes Community Governance](https://github.com/kubernetes/community/blob/master/governance.md) and uses
+the Roles and Organization Management outlined in [sig-governance](../../SIG-Governance.md).
+
+# Scope
+
+SIG Content is responsible for maintaining CNOE content, including content on our web properties (primarily cnoe.io). 
+
+## Out of scope
+
+Content within the code repositories of our tools, such as in-repository documentation of idpbuilder and stacks \(which are governed by [SIG IDP-Builders](../idp-builders/charter.md)\) is out of scope. However, content on the cnoe.io website which references these tools *is* in the scope of this SIG.
+
+## Repositories
+
+# Roles and Organization Management
+
+## Leadership


### PR DESCRIPTION
We've seen great community participation and growth, and we've also gotten feedback during the SIG IDP Builders technical meeting that community members are looking for guidance on how to contribute outside of our tooling.

To address this, I am proposing we create a new SIG Content which will serve as a delegation group from the Steering Committee to facilitate community contribution to content, especially on our cnoe.io website.

Details of who would be on this committee and review process for contributions are still TBD based on steering committee feedback.